### PR TITLE
Fix userContent for PhaseRoot case

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -989,7 +989,7 @@ export class Task {
 		await this.say("text", task, images, files)
 		this.taskState.isInitialized = true
 
-		let finalTask = task
+		let finalTask = task || ""
 		// Apply prompt refinement if enabled and task is provided
 		if (task && this.autoApprovalSettings.actions.usePromptRefinement) {
 			try {
@@ -1063,7 +1063,13 @@ export class Task {
 		let imageBlocks: Anthropic.ImageBlockParam[] = formatResponse.imageBlocks(images)
 		let userContent: UserContent = []
 		if (this.isPhaseRoot) {
-			userContent = [{ type: "text", text: `${PROMPTS.PLANNING}\n\n<task>\n${finalTask}\n</task>` }, ...imageBlocks]
+			userContent = [
+				{
+					type: "text",
+					text: `${PROMPTS.PLANNING}\n\n<task>\n${finalTask === "" ? phaseAwarePrompt : finalTask}\n</task>`,
+				},
+				...imageBlocks,
+			]
 		} else {
 			userContent = [{ type: "text", text: `<task>\n${phaseAwarePrompt}\n</task>` }, ...imageBlocks]
 		}


### PR DESCRIPTION
### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->
- Fix text of userContent input when refinePrompt is False, so phaseAwarePrompt used as input directly

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
