### PR TITLE
Prevent redundant refine step during phase execution

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -57,7 +57,7 @@ export class Controller {
 	private postMessage: (message: ExtensionMessage) => Thenable<boolean> | undefined
 
 	private disposables: vscode.Disposable[] = []
-	private mode: "plan" | "act" = "plan" // In-memory plan/act mode state
+	private mode: "plan" | "act" = "act" // In-memory plan/act mode state
 	task?: Task
 	public phaseTracker?: PhaseTracker
 	workspaceTracker: WorkspaceTracker

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -999,7 +999,7 @@ export class Task {
 
 		let finalTask = task
 		// Apply prompt refinement if enabled and task is provided
-		if (task && this.autoApprovalSettings.actions.usePromptRefinement) {
+		if (this.isPhaseRoot && task && this.autoApprovalSettings.actions.usePromptRefinement) {
 			try {
 				console.log("[Task] Applying prompt refinement...")
 				await this.say(
@@ -1065,6 +1065,18 @@ export class Task {
 			} catch (error) {
 				console.error("[Task] Prompt refinement failed:", error)
 				// Continue with original prompt if refinement fails
+			}
+		}
+
+		if (
+			this.isPhaseRoot &&
+			this.autoApprovalSettings.actions.usePromptRefinement &&
+			this.autoApprovalSettings.actions.usePhasePlanning
+		) {
+			const approved = await this.askUserApproval("ask_question", "Proceed to Planning Phase with the refined prompt?")
+			if (!approved) {
+				await this.say("text", "Proceed to Planning Phase aborted by user.")
+				return
 			}
 		}
 


### PR DESCRIPTION
- Prevent redundant refine step during phase execution
- Set act mode as default
- Add approval between refinement and planning

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)


