### PR TITLE
New Task 생성 시 Phase Reset 기능 구현

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -134,10 +134,25 @@ export class Controller {
 	/**
 	 * spawnNewTask - 현재 진행 중인 Task를 완전히 종료하고,
 	 * 새 task + 새 PhaseTracker를 생성한다.
+	 * @returns true if task was created, false if cancelled
 	 */
-	public async spawnNewTask(newPrompt?: string, images?: string[]) {
+	public async spawnNewTask(newPrompt?: string, images?: string[]): Promise<boolean> {
 		// initTask() already clears any existing task and phase tracker
-		await this.initTask(newPrompt, images)
+		const selection = await vscode.window.showInformationMessage(
+			"Planning 중 새로운 Task 생성 시 기존 Planning이 초기화 됩니다. \n 새로운 Task를 생성하시겠습니까?",
+			"Yes",
+			"No",
+		)
+		if (selection === "Yes") {
+			this.phaseTracker?.deleteCheckpoint()
+			this.phaseTracker = undefined
+			await this.initTask(newPrompt, images)
+			return true
+		} else {
+			// 사용자가 'Cancel'을 선택했을 때 실행할 로직
+			vscode.window.showInformationMessage("새로운 Task 생성이 취소되었습니다.")
+			return false
+		}
 	}
 
 	async initTask(task?: string, images?: string[], files?: string[], historyItem?: HistoryItem) {

--- a/src/core/controller/task/newTask.ts
+++ b/src/core/controller/task/newTask.ts
@@ -10,7 +10,15 @@ import { handleFileServiceRequest } from "../file"
  * @returns Empty response
  */
 export async function newTask(controller: Controller, request: NewTaskRequest): Promise<Empty> {
-	// await controller.spawnNewTask(request.text, request.images)
-	await controller.initTask(request.text, request.images, request.files, undefined)
+	if (controller.phaseTracker === undefined) {
+		await controller.initTask(request.text, request.images)
+	} else {
+		const taskCreated = await controller.spawnNewTask(request.text, request.images)
+		if (!taskCreated) {
+			// User cancelled the task creation, don't return Empty.create()
+			// This will prevent the gRPC response from being sent immediately
+			throw new Error("Task creation cancelled by user")
+		}
+	}
 	return Empty.create()
 }

--- a/src/core/planning/phase-tracker.ts
+++ b/src/core/planning/phase-tracker.ts
@@ -804,4 +804,36 @@ export class PhaseTracker {
 			// Note: Plan markdown is saved during initial parsing, not during checkpoint saves
 		} catch (error) {}
 	}
+
+	public async deleteCheckpoint(): Promise<void> {
+		try {
+			// 1) 저장 경로 계산 (saveCheckpoint와 동일)
+			let baseUri: vscode.Uri
+			const ws = vscode.workspace.workspaceFolders
+			if (ws && ws.length > 0) {
+				baseUri = vscode.Uri.joinPath(ws[0].uri, ".cline")
+			} else {
+				baseUri = vscode.Uri.joinPath(this.controller.context.globalStorageUri, ".cline")
+			}
+
+			// 2) phase-checkpoint.json 파일 경로 지정
+			const checkpointUri = vscode.Uri.joinPath(baseUri, "phase-checkpoint.json")
+
+			// 3) 파일 존재 여부 확인
+			try {
+				const stat = await vscode.workspace.fs.stat(checkpointUri)
+				console.log(`[deleteCheckpoint] File exists at: ${checkpointUri.toString()}`)
+			} catch (statError) {
+				console.log(`[deleteCheckpoint] File does not exist at: ${checkpointUri.toString()}`)
+				return // 파일이 없으면 삭제할 필요 없음
+			}
+
+			// 4) 파일 삭제 시도
+			await vscode.workspace.fs.delete(checkpointUri, {
+				recursive: false,
+				useTrash: false,
+			})
+			console.log(`[deleteCheckpoint] Successfully deleted: ${checkpointUri.toString()}`)
+		} catch (error) {}
+	}
 }


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #45

### Description

Planning 중간에 New Task 생성 시 기존 Planning 정보를 계속 가져오는 현상 조치

#### 조치 방법
1. Planning 중간 New Task 생성 시도 시 아래와 같은 팝업 발생

  ![image](https://github.com/user-attachments/assets/4eaaa546-929f-4249-aeb4-3c018d2e9574)

2. No 선택 시 별도의 동작 없음 (기존 Planning 정보 유지)
3. Yes 선택 시 Planning Tracker 초기화 및 checkpoint.json 파일 삭제
