### PR TITLE
RefinePrompt 실패 시 retry 및 reject 로직 추가 (develop rebase 후 PR 재도전..!)

### DIFF
--- a/src/core/task/prompt-refinement.ts
+++ b/src/core/task/prompt-refinement.ts
@@ -21,6 +21,7 @@ export interface RefinedPromptResult {
 	followUpQuestions: FollowUpQuestion[]
 	originalPrompt: string
 	explanation: string
+	success: boolean
 }
 
 // Template
@@ -274,6 +275,7 @@ export async function refinePrompt(prompt: string, apiHandler: ApiHandler, taskI
 			explanation: refinedPrompt.explanation,
 			needsMoreInfo: refinedPrompt.needsMoreInfo || false,
 			followUpQuestions: refinedPrompt.followUpQuestions || [],
+			success: true,
 		}
 	} catch (error) {
 		console.error("Error in prompt refinement:", error)
@@ -283,6 +285,7 @@ export async function refinePrompt(prompt: string, apiHandler: ApiHandler, taskI
 			explanation: `LLM refinement failed.`,
 			needsMoreInfo: false,
 			followUpQuestions: [],
+			success: false,
 		}
 	}
 }


### PR DESCRIPTION
develop rebase 후 다시 도전하는 PR입니다!
이전 리뷰 시 불필요했던 originalTask 변수도 삭제 완료했습니다!

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #74

### Description

- refine promt 실패 시 최대 2번 retry 의사를 물어보도록 로직 수정
- retry 횟수가 2번을 초과하거나 사용자가 skip할 시 기존 프롬프트가 들어가도록 로직 추가

  ![image](https://github.com/user-attachments/assets/cdcb3842-be84-4757-9821-10ee5e854385)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->
-  ✨ New feature (non-breaking change which adds functionality)

