### PR TITLE
Use temp api for planning with openrouter

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -119,6 +119,7 @@ export class Task {
 
 	// Task configuration
 	private enableCheckpoints: boolean
+	private originalApiConfiguration: ApiConfiguration
 
 	// Core dependencies
 	private context: vscode.ExtensionContext
@@ -222,6 +223,7 @@ export class Task {
 		this.cwd = cwd
 
 		this.taskState.isPhaseRoot = isPhaseRoot
+		this.originalApiConfiguration = apiConfiguration
 
 		// Set up MCP notification callback for real-time notifications
 		this.mcpHub.setNotificationCallback(async (serverName: string, level: string, message: string) => {
@@ -384,18 +386,11 @@ export class Task {
 
 	// Create a temporary API handler with a specific model
 	private createTemporaryApiHandler(modelName: string): ApiHandler {
-		// Copy the current API configuration directly from this.api
-		// We need to maintain the original API's configuration and just change the model
-		const currentApi = this.api
-
-		// Create a new configuration with the specified model
 		// Get apiProvider and other properties directly from the original API
 		const tempConfig: ApiConfiguration = {
-			...(currentApi as any).options, // Directly access the options property if it exists
-			apiProvider: (currentApi as any).options?.apiProvider,
-			apiKey: (currentApi as any).options?.apiKey,
-			apiModelId: modelName, // Override with the requested model
-			taskId: this.taskId, // Ensure task ID is preserved
+			...this.originalApiConfiguration,
+			actModeOpenRouterModelId: modelName, // Override with the requested model
+			taskId: this.taskId, // Ensure task ID is prethis.originalApiConfiguration = apiConfigurationserved
 		}
 
 		// Build and return the temporary API handler
@@ -1724,7 +1719,7 @@ export class Task {
 		}
 
 		// reuse the existing streaming machinery
-		const firstStream = this.attemptApiRequest(/*prevIndex=*/ -1, "claude-sonnet-4-20250514")
+		const firstStream = this.attemptApiRequest(/*prevIndex=*/ -1, "anthropic/claude-sonnet-4")
 		let assistantText = ""
 		const start = performance.now()
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -390,7 +390,7 @@ export class Task {
 		const tempConfig: ApiConfiguration = {
 			...this.originalApiConfiguration,
 			actModeOpenRouterModelId: modelName, // Override with the requested model
-			taskId: this.taskId, // Ensure task ID is prethis.originalApiConfiguration = apiConfigurationserved
+			taskId: this.taskId, // Ensure task ID is preserved
 		}
 
 		// Build and return the temporary API handler


### PR DESCRIPTION
### Description

- Use temp api for planning with openrouter
- Reflect changes from the previous PR in the refine prompt again


### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)