### PR TITLE
Fix warning for vscode window message

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -2,7 +2,7 @@ import { clineEnvConfig } from "@/config"
 import { HostProvider } from "@/hosts/host-provider"
 import { AuthService } from "@/services/auth/AuthService"
 import { PostHogClientProvider, telemetryService } from "@/services/posthog/PostHogClientProvider"
-import { ShowMessageType } from "@/shared/proto/host/window"
+import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { getLatestAnnouncementId } from "@/utils/announcements"
 import { getCwd, getDesktopDir } from "@/utils/path"
 import { Anthropic } from "@anthropic-ai/sdk"
@@ -172,20 +172,30 @@ export class Controller {
 	 */
 	public async spawnNewTask(newPrompt?: string, images?: string[], files?: string[]): Promise<boolean> {
 		// initTask() already clears any existing task and phase tracker
-		const selection = await vscode.window.showInformationMessage(
-			"Planning 중 새로운 Task 생성 시 기존 Planning이 초기화 됩니다. \n 새로운 Task를 생성하시겠습니까?",
-			"Yes",
-			"No",
+		const response = await HostProvider.window.showMessage(
+			ShowMessageRequest.create({
+				type: ShowMessageType.INFORMATION,
+				message: "Planning 중 새로운 Task 생성 시 기존 Planning이 초기화 됩니다. \n 새로운 Task를 생성하시겠습니까?",
+				options: {
+					items: ["Yes", "No"],
+				},
+			}),
 		)
-		if (selection === "Yes") {
+
+		if (response.selectedOption === "Yes") {
 			this.phaseTracker?.deleteCheckpoint()
 			this.phaseTracker?.deletePlanMD()
 			this.phaseTracker = undefined
 			await this.initTask(newPrompt, images, files)
 			return true
 		} else {
-			// 사용자가 'Cancel'을 선택했을 때 실행할 로직
-			vscode.window.showInformationMessage("새로운 Task 생성이 취소되었습니다.")
+			// 사용자가 'No'를 선택하거나 취소했을 때 실행할 로직
+			if (response.selectedOption === "No") {
+				HostProvider.window.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message: "새로운 Task 생성이 취소되었습니다.",
+				})
+			}
 			return false
 		}
 	}
@@ -867,11 +877,6 @@ export class Controller {
 		if (!current.status || current.status === "in-progress") {
 			await tracker.completePhase(currentIndex)
 		}
-	}
-
-	public async onTaskCompleted(): Promise<void> {
-		vscode.window.showInformationMessage("🎉 All phases finished!")
-		this.phaseTracker = undefined // reset phase tracker
 	}
 
 	public async spawnPhaseTask(phasePrompt: string, phaseId: number): Promise<string> {

--- a/src/core/planning/phase-tracker.ts
+++ b/src/core/planning/phase-tracker.ts
@@ -1282,7 +1282,7 @@ export class PhaseTracker {
 
 			// 2) Create the .cline directory if it doesn't exist
 			if (!(await fileExistsAtPath(baseUri.fsPath))) {
-				await createDirectoriesForFile(baseUri.fsPath + "/dummy")
+				await createDirectoriesForFile(baseUri.fsPath)
 			}
 
 			// 3) Prepare checkpoint data

--- a/src/core/planning/phase-tracker.ts
+++ b/src/core/planning/phase-tracker.ts
@@ -1,6 +1,9 @@
 import * as vscode from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
 import { Controller } from "../controller"
 import { extractTag, extractTagAsLines, PHASE_RETRY_LIMIT } from "./utils"
+import { writeFile, fileExistsAtPath, createDirectoriesForFile } from "@/utils/fs"
+import fs from "fs/promises"
 
 export enum PhaseStatus {
 	Pending = "pending",
@@ -849,8 +852,7 @@ export async function parsePlanFromFixedFile(
 		const devPlanFileUri = vscode.Uri.joinPath(extensionContext.extensionUri, "src", "core", "assistant-message", "plan.txt")
 
 		console.log("[parsePlanFromFixedFile] Trying dev path:", devPlanFileUri.toString())
-		const planContentBytes = await vscode.workspace.fs.readFile(devPlanFileUri)
-		const planContent = new TextDecoder().decode(planContentBytes)
+		const planContent = await fs.readFile(devPlanFileUri.fsPath, "utf8")
 
 		console.log("[parsePlanFromFixedFile] Successfully loaded plan.txt from dev path")
 		console.log("[parsePlanFromFixedFile] Content length:", planContent.length)
@@ -871,8 +873,7 @@ export async function parsePlanFromFixedFile(
 			)
 
 			console.log("[parsePlanFromFixedFile] Trying dist path:", planFileUri.toString())
-			const planContentBytes = await vscode.workspace.fs.readFile(planFileUri)
-			const planContent = new TextDecoder().decode(planContentBytes)
+			const planContent = await fs.readFile(planFileUri.fsPath, "utf8")
 
 			console.log("[parsePlanFromFixedFile] Successfully loaded plan.txt from dist path")
 			console.log("[parsePlanFromFixedFile] Content length:", planContent.length)
@@ -1219,13 +1220,13 @@ export class PhaseTracker {
 		return this.projOverview
 	}
 
-	public getBaseUri(controller: Controller): vscode.Uri {
+	public async getBaseUri(controller: Controller): Promise<vscode.Uri> {
 		// Determine the base URI for storage (prefer workspace, fallback to globalStorage)
 		let baseUri: vscode.Uri
-		const ws = vscode.workspace.workspaceFolders
-		if (ws && ws.length > 0) {
+		const workspacePaths = await HostProvider.workspace.getWorkspacePaths({})
+		if (workspacePaths.paths && workspacePaths.paths.length > 0) {
 			// If workspace is open, create .cline directory under the first folder
-			baseUri = vscode.Uri.joinPath(ws[0].uri, ".cline")
+			baseUri = vscode.Uri.joinPath(vscode.Uri.file(workspacePaths.paths[0]), ".cline")
 		} else {
 			// If no workspace is available, use the extension's globalStorageUri
 			// ("globalStorage" permission is required in package.json)
@@ -1235,10 +1236,10 @@ export class PhaseTracker {
 	}
 
 	public checkpointUri: vscode.Uri | undefined = undefined
-	get checkpointFileUri(): vscode.Uri {
+	async getCheckpointFileUri(): Promise<vscode.Uri> {
 		// Get the base URI for storage
 		if (!this.checkpointUri) {
-			const baseUri = this.getBaseUri(this.controller)
+			const baseUri = await this.getBaseUri(this.controller)
 			// Return the full path to the checkpoint file
 			this.checkpointUri = vscode.Uri.joinPath(baseUri, "phase-checkpoint.json")
 			return this.checkpointUri
@@ -1251,11 +1252,10 @@ export class PhaseTracker {
 	/** Restore tracker progress from .cline/phase-checkpoint.json if present */
 	public async fromCheckpoint(): Promise<PhaseTracker | undefined> {
 		try {
-			const checkpointUri = this.checkpointFileUri
+			const checkpointUri = await this.getCheckpointFileUri()
 
 			// Read file
-			const data = await vscode.workspace.fs.readFile(checkpointUri)
-			const text = new TextDecoder().decode(data)
+			const text = await fs.readFile(checkpointUri.fsPath, "utf8")
 			const checkpoint = JSON.parse(text)
 
 			// Restore PhaseTracker
@@ -1278,13 +1278,11 @@ export class PhaseTracker {
 	public async saveCheckpoint(): Promise<void> {
 		try {
 			// 1) Determine the base URI for saving
-			const baseUri = this.getBaseUri(this.controller)
+			const baseUri = await this.getBaseUri(this.controller)
 
 			// 2) Create the .cline directory if it doesn't exist
-			try {
-				await vscode.workspace.fs.stat(baseUri)
-			} catch {
-				await vscode.workspace.fs.createDirectory(baseUri)
+			if (!(await fileExistsAtPath(baseUri.fsPath))) {
+				await createDirectoriesForFile(baseUri.fsPath + "/dummy")
 			}
 
 			// 3) Prepare checkpoint data
@@ -1297,12 +1295,11 @@ export class PhaseTracker {
 			}
 			const content = JSON.stringify(checkpointData, null, 2)
 
-			// Simply use the getter which already computes the proper URI
-			const checkpointUri = this.checkpointFileUri
+			// Simply use the method which already computes the proper URI
+			const checkpointUri = await this.getCheckpointFileUri()
 			const tmpUri = vscode.Uri.joinPath(baseUri, "phase-checkpoint.json.tmp")
-			const encoder = new TextEncoder()
-			await vscode.workspace.fs.writeFile(tmpUri, encoder.encode(content))
-			await vscode.workspace.fs.rename(tmpUri, checkpointUri, { overwrite: true })
+			await writeFile(tmpUri.fsPath, content)
+			await fs.rename(tmpUri.fsPath, checkpointUri.fsPath)
 
 			// Note: Plan markdown is saved during initial parsing, not during checkpoint saves
 		} catch (error) {}
@@ -1310,43 +1307,33 @@ export class PhaseTracker {
 
 	public async deleteCheckpoint(): Promise<void> {
 		try {
-			const checkpointUri = this.checkpointFileUri
+			const checkpointUri = await this.getCheckpointFileUri()
 
-			try {
-				await vscode.workspace.fs.stat(checkpointUri)
+			if (await fileExistsAtPath(checkpointUri.fsPath)) {
 				console.log(`[deleteCheckpoint] File exists at: ${checkpointUri.toString()}`)
-			} catch (statError) {
+				await fs.unlink(checkpointUri.fsPath)
+			} else {
 				console.log(`[deleteCheckpoint] File does not exist at: ${checkpointUri.toString()}`)
 				return
 			}
-
-			await vscode.workspace.fs.delete(checkpointUri, {
-				recursive: false,
-				useTrash: false,
-			})
 			console.log(`[deleteCheckpoint] Successfully deleted: ${checkpointUri.toString()}`)
 		} catch (error) {}
 	}
 
 	public async deletePlanMD(): Promise<void> {
 		try {
-			const baseUri = this.getBaseUri(this.controller)
+			const baseUri = await this.getBaseUri(this.controller)
 			const taskId = this.phaseStates[0].taskId
 			const filename = `project-execution-plan-${taskId}.md`
 			const fileUri = vscode.Uri.joinPath(baseUri, filename)
 
-			try {
-				await vscode.workspace.fs.stat(fileUri)
+			if (await fileExistsAtPath(fileUri.fsPath)) {
 				console.log(`[deletePlanMD] File exists at: ${fileUri.toString()}`)
-			} catch (statError) {
+				await fs.unlink(fileUri.fsPath)
+			} else {
 				console.log(`[deletePlanMD] File does not exist at: ${fileUri.toString()}`)
 				return
 			}
-
-			await vscode.workspace.fs.delete(fileUri, {
-				recursive: false,
-				useTrash: false,
-			})
 			console.log(`[deletePlanMD] Successfully deleted: ${fileUri.toString()}`)
 		} catch (error) {}
 	}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1241,7 +1241,7 @@ export class Task {
 				}
 				this.sidebarController.phaseTracker.updateTaskIdPhase(0, this.taskId)
 
-				const saveUri = this.sidebarController.phaseTracker.getBaseUri(this.sidebarController)
+				const saveUri = await this.sidebarController.phaseTracker.getBaseUri(this.sidebarController)
 
 				// Phase Plan을 parsing하여 구조화된 데이터로 변환
 				const { projOverview, executionPlan, phases: planSteps } = parsePlanFromOutput(firstAssistantMessage)
@@ -1351,7 +1351,6 @@ export class Task {
 			}
 			this.taskState.newPhaseOpened = false
 		}
-		this.sidebarController.onTaskCompleted()
 	}
 
 	public async runSinglePhase(currentPhasePrompt: string): Promise<void> {
@@ -2100,7 +2099,22 @@ export class Task {
 		}
 		Logger.info("Executing command in terminal: " + command)
 
-		const terminalInfo = await this.terminalManager.getOrCreateTerminal(this.cwd)
+		// Try to get current working directory from existing terminal first
+		const terminals = this.terminalManager.filterTerminals((t) => !t.busy)
+		const activeTerminal = terminals[0]
+
+		// If we have an active terminal, use it without changing directory
+		// Only use task's initial cwd if no terminal exists
+		let terminalInfo: any
+		if (activeTerminal) {
+			const currentCwd = activeTerminal.terminal.shellIntegration?.cwd?.fsPath || "unknown"
+			console.log(`[Task] Reusing existing terminal in directory: ${currentCwd}`)
+			// Pass the terminal's current directory to avoid unnecessary cd commands
+			terminalInfo = await this.terminalManager.getOrCreateTerminal(currentCwd)
+		} else {
+			console.log(`[Task] Creating new terminal in task cwd: ${this.cwd}`)
+			terminalInfo = await this.terminalManager.getOrCreateTerminal(this.cwd)
+		}
 		terminalInfo.terminal.show() // weird visual bug when creating new terminals (even manually) where there's an empty space at the top.
 		const process = this.terminalManager.runCommand(terminalInfo, command)
 


### PR DESCRIPTION
### Description

- Fix warning for vscode window message
- `Use utilities in @/utils/fs instead of vscode.workspace.fsExample: import { isDirectory } from '@/utils/fs' or use the file system methods from the host bridge provider.` 나 `Use HostProvider.workspace.getWorkspacePaths({}) instead of vscode.workspace.workspaceFolders.This provides a consistent abstraction across VSCode and standalone environments.` 와 같은 warning이 반복적으로 발생하는 것으로 인해 수정

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
