### PR TITLE
Add button config for planning and phase proceed

### DIFF
--- a/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -59,6 +59,10 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 						case "new_task":
 						case "condense":
 						case "report_bug":
+						case "ask_proceed":
+						case "ask_retry":
+						case "ask_final_retry":
+						case "ask_check":
 							await TaskServiceClient.askResponse(
 								AskResponseRequest.create({
 									responseType: "messageResponse",
@@ -230,8 +234,11 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 				case "Run Command":
 				case "Retry":
 				case "Switch to Act Mode":
+				case "Yes":
 					actionType = "approve"
 					break
+				case "Skip":
+				case "Finish Task":
 				case "Reject":
 					actionType = "reject"
 					break

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -204,6 +204,40 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 		primaryAction: undefined,
 		secondaryAction: "cancel",
 	},
+
+	// Planning
+	ask_proceed: {
+		sendingDisabled: true,
+		enableButtons: true,
+		primaryText: "Proceed",
+		secondaryText: "Reject",
+		primaryAction: "proceed",
+		secondaryAction: "reject",
+	},
+	ask_retry: {
+		sendingDisabled: true,
+		enableButtons: true,
+		primaryText: "Retry",
+		secondaryText: "Skip",
+		primaryAction: "approve",
+		secondaryAction: "reject",
+	},
+	ask_final_retry: {
+		sendingDisabled: true,
+		enableButtons: true,
+		primaryText: "Retry",
+		secondaryText: "Finish Task",
+		primaryAction: "approve",
+		secondaryAction: "reject",
+	},
+	ask_check: {
+		sendingDisabled: true,
+		enableButtons: true,
+		primaryText: "Yes",
+		secondaryText: undefined,
+		primaryAction: "approve",
+		secondaryAction: undefined,
+	},
 }
 
 const errorTypes = ["api_req_failed", "mistake_limit_reached", "auto_approval_max_req_reached"]
@@ -285,6 +319,16 @@ export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode =
 
 			default:
 				return BUTTON_CONFIGS.tool_approve
+
+			// Planning
+			case "ask_proceed":
+				return BUTTON_CONFIGS.ask_proceed
+			case "ask_retry":
+				return BUTTON_CONFIGS.ask_retry
+			case "ask_final_retry":
+				return BUTTON_CONFIGS.ask_final_retry
+			case "ask_check":
+				return BUTTON_CONFIGS.ask_check
 		}
 	}
 


### PR DESCRIPTION


### Description

- Add button config for planning and phase proceed
- Add button action for planning and phase proceed
- rebase 하면서 webview 부분에 button 에 대한 정보가 없어지고, 이를 messagehandler 와 button config로 별도로 관리를 시작하여
없어진 부분이 있어 별도 PR로 추가

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
