### PR TITLE
Replace import for Apihandler in prompt-refinement to fix error

### DIFF
--- a/src/core/task/prompt-refinement.ts
+++ b/src/core/task/prompt-refinement.ts
@@ -1,9 +1,9 @@
-import { ApiHandler } from "@api/index"
-import { HostProvider } from "@/hosts/host-provider"
+import { ApiHandler } from "@core/api"
 import { findLastIndex } from "@shared/array"
 import { ClineApiReqInfo, ClineAskQuestion, ClineMessage } from "@shared/ExtensionMessage"
-import { writeFile } from "@/utils/fs"
 import * as vscode from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
+import { writeFile } from "@/utils/fs"
 
 export interface FollowUpQuestion {
 	question: string


### PR DESCRIPTION
### Description
- fix: replace import for Apihandler in prompt-refinement to fix error
- We could meet `src/core/task/prompt-refinement.ts:1:28 - error TS2307: Cannot find module '@api/index' or its corresponding type declarations.` error during building Cline.
- To fix this, we replace import `import { ApiHandler } from "@api/index"` into `import { ApiHandler } from "@core/api"` like other files. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
